### PR TITLE
Fixed bug where testfiles with one test failed

### DIFF
--- a/app/plugins/autograder/pythongrader.py
+++ b/app/plugins/autograder/pythongrader.py
@@ -58,7 +58,7 @@ def runTests(cmdPrefix, testFile, timeLimit):
   summary['rawErr'] = testError
 
   #Parse the results
-  testSummarySearch = re.search("Ran ([0-9]+) tests in", testError)
+  testSummarySearch = re.search("Ran ([0-9]+) tests? in", testError)
 
   #If we don't find the test summary the tests died so we report that
   if not testSummarySearch:


### PR DESCRIPTION
Testing against a file with single test was failing because the re for the test summary was accepting only "tests" and not "test".